### PR TITLE
build: fix compile error when -Werror=return-type is used

### DIFF
--- a/code/latte/ReadPolyhedron.cpp
+++ b/code/latte/ReadPolyhedron.cpp
@@ -1224,7 +1224,7 @@ exit(1);
 //			dilationNum = (dilationNum *  (cone->vertex->vertex->denominators())[i])/ GCD(dilationNum, (cone->vertex->vertex->denominators())[i]);
 //	}
 
-
+	return RationalNTL();
 }//ReadPolyhedronDataRecursive
 
 int ReadPolyhedronDataRecursive::getNumberEqualities() const


### PR DESCRIPTION
openSUSE adds -Werror=return-type into the default cflags for good measure, pointing out one place where garbage return values would occur.

```
» ./configure CXXFLAGS=-Werror=return-type && make

ReadPolyhedron.cpp: In member function ‘RationalNTL ReadPolyhedronDataRecursive::getNormalFactor() const’:
ReadPolyhedron.cpp:1228:1: error: control reaches end of non-void function [-Werror=return-type]
 1228 | }//ReadPolyhedronDataRecursive
      | ^
```