### PR TITLE
Fix a couple typos

### DIFF
--- a/code/latte/ReadingFile.cpp
+++ b/code/latte/ReadingFile.cpp
@@ -581,8 +581,8 @@ void CheckLength2(const char * filename, char * equ)
 
    if(Total > counts){
      ofstream out("Error");
-     out << "The wrong number of elements in the file.  The number of elements are less than you indicated" << endl;
-     cerr <<"The wrong number of elements in the file.  The number of elements are less than you indicated." << endl;
+     out << "Wrong number of elements in the file: there are less than you indicated." << endl;
+     cerr << "Wrong number of elements in the file: there are less than you indicated." << endl;
      exit (1);
    }
    /*   else if(Total < counts){

--- a/code/latte/ReadingFile.cpp
+++ b/code/latte/ReadingFile.cpp
@@ -581,8 +581,8 @@ void CheckLength2(const char * filename, char * equ)
 
    if(Total > counts){
      ofstream out("Error");
-     out << "The wrong number of elements in the file.  The number of elments are less than you indicated" << endl;
-     cerr <<"The wrong number of elements in the file.  The number of elments are less than you indicated." << endl;
+     out << "The wrong number of elements in the file.  The number of elements are less than you indicated" << endl;
+     cerr <<"The wrong number of elements in the file.  The number of elements are less than you indicated." << endl;
      exit (1);
    }
    /*   else if(Total < counts){

--- a/code/latte/RudyResNTL.cpp
+++ b/code/latte/RudyResNTL.cpp
@@ -540,7 +540,7 @@ vec_ZZ ResidueFunction(listCone* cones, int numOfVars, int print_flag,
 	if(print_flag == 1)
 		 {
 		   //system_with_error_check("rm func.rat");
-	 		 cerr << "Outputing rational functions to file" << endl;
+			cerr << "Outputting rational functions to file" << endl;
 			Rational_Function_Output_File.open ("func.rat");
 		 }
 

--- a/code/latte/convertCDD_ext_to_latte.cpp
+++ b/code/latte/convertCDD_ext_to_latte.cpp
@@ -21,7 +21,7 @@ int main( int argc, const char* argv[] )
 {
 	if ( argc != 3)
 	{
-		cout << "usage: " << argv[0] << "inputFileName.ine outputFileName" << endl;
+		cout << "usage: " << argv[0] << " inputFileName.ine outputFileName" << endl;
 		exit(1);
 	}
 	cout << "not implemented yet" << endl;

--- a/code/latte/convertCDD_ine_to_latte.cpp
+++ b/code/latte/convertCDD_ine_to_latte.cpp
@@ -21,7 +21,7 @@ int main( int argc, const char* argv[] )
 {
 	if ( argc != 3)
 	{
-		cout << "usage: " << argv[0] << "inputFileName.ine outputFileName" << endl;
+		cout << "usage: " << argv[0] << " inputFileName.ine outputFileName" << endl;
 		exit(1);
 	}
 


### PR DESCRIPTION
Fixed two misspellings ("elements" and "outputting") and added a space in the "usage" message for the CDD conversion utilities so we don't get the following:

```
$ ./ConvertCDDextToLatte
usage: ./ConvertCDDextToLatteinputFileName.ine outputFileName
```