### PR TITLE
Fix `--enable-database` and `--enable-programmer-helper`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,7 +173,7 @@ if test x$enable_experiments = xyes ; then
    AC_DEFINE(HAVE_EXPERIMENTS, 1, [Define if experimental code is enabled])
 fi
 
-AC_ARG_ENABLE(DATABASE, AS_HELP_STRING([--enable-database],
+AC_ARG_ENABLE(database, AS_HELP_STRING([--enable-database],
 	[use database code]))
 AM_CONDITIONAL(HAVE_DATABASE, test x$enable_database = xyes)
 if test x$enable_database = xyes ; then
@@ -182,7 +182,7 @@ fi
 
 #builds mini integration drivers
 #	or programs only latte programmers care about
-AC_ARG_ENABLE(PROGRAMMER_HELPER, AS_HELP_STRING([--enable-programmer-helper],
+AC_ARG_ENABLE(programmer-helper, AS_HELP_STRING([--enable-programmer-helper],
 	[build extra programs]))
 AM_CONDITIONAL(HAVE_PROGRAMMER_HELPER, test x$enable_programmer_helper = xyes)
 if test x$enable_programmer_helper = xyes ; then


### PR DESCRIPTION
Before that commit autoconf expects `--enable-DATABASE` and `--enable-PROGRAMMER-HELPER` which produces variables when defined `enable_DATABASE` and `enable_PROGRAMMER_HELPER`. Which never tested.

As result it was impossible to enable such features